### PR TITLE
from confit to confuse

### DIFF
--- a/beetsplug/describe/__init__.py
+++ b/beetsplug/describe/__init__.py
@@ -7,7 +7,7 @@
 import os
 
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigSource, load_yaml
+from confuse import ConfigSource, load_yaml
 
 from beetsplug.describe.command import DescribeCommand
 

--- a/beetsplug/describe/command.py
+++ b/beetsplug/describe/command.py
@@ -14,7 +14,7 @@ from beets import library
 from beets.dbcore import types
 from beets.library import Library, Item, parse_query_parts
 from beets.ui import Subcommand, decargs
-from beets.util.confit import Subview
+from confuse import Subview
 
 from beetsplug.describe import common
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -24,7 +24,7 @@ from beets.util import (
     bytestring_path,
     displayable_path,
 )
-from beets.util.confit import Subview, Dumper
+from confuse import Subview, Dumper
 from six import StringIO
 
 from beetsplug import describe


### PR DESCRIPTION
This should fix https://github.com/adamjakab/BeetsPluginDescribe/issues/4 (deprecations warning for the old beets config lib).

This has been tested by @JOJ0 and seems to work, removing the warnings.