### PR TITLE
Adapt to recent beets core changes

### DIFF
--- a/beetsplug/describe/command.py
+++ b/beetsplug/describe/command.py
@@ -13,7 +13,7 @@ from beets import library
 
 from beets.dbcore import types
 from beets.library import Library, Item, parse_query_parts
-from beets.ui import Subcommand, decargs
+from beets.ui import Subcommand
 from confuse import Subview
 
 from beetsplug.describe import common
@@ -50,7 +50,7 @@ class DescribeCommand(Subcommand):
 
     def func(self, lib: Library, options, arguments):
         self.lib = lib
-        self.query = decargs(arguments)
+        self.query = arguments
 
         # You must either pass a training name or request listing
         if len(self.query) < 1 and not options.version:

--- a/beetsplug/describe/common.py
+++ b/beetsplug/describe/common.py
@@ -8,7 +8,6 @@ import logging
 import os
 import sys
 
-from beets import library
 from beets.dbcore import types
 from beets.library import Item
 
@@ -71,7 +70,7 @@ def get_dbcore_numeric_types():
         types.PaddedInt,
         types.NullPaddedInt,
         types.ScaledInt,
-        library.DurationType
+        types.DurationType
     ]
 
     for dt in dbcore_types:


### PR DESCRIPTION

- `decargs` was removed from beets core. I fixed the import and passed args directly. see https://github.com/beetbox/beets/commit/a815305fcd7834da2afe1feac0e786c44d4979b2
- `DurationType` was moved to a `types` module. Fixed.

These changes make the plugin functional again. Hope it helps and all the best!